### PR TITLE
Fix requiring files with ES2015 imports in node

### DIFF
--- a/src/d3-flextree.js
+++ b/src/d3-flextree.js
@@ -1,5 +1,5 @@
 'use strict';
-const Node = require('d3-hierarchy/src/hierarchy/index').Node;
+const Node = require('d3-hierarchy').hierarchy.prototype.constructor;
 
 // Node-link tree diagram using the Reingold-Tilford "tidy" algorithm,
 // as improved by A.J. van der Ploeg, 2013, "Drawing Non-layered Tidy


### PR DESCRIPTION
The file `d3-hierarchy/src/hierarchy/index` has ES2015 imports, which means it doesn't play well when importing into NodeJS. We can alternatively get the `Node` constructor from `hierarchy`'s prototype.